### PR TITLE
Auto-Restart Flask App with Systemd Timer

### DIFF
--- a/Scripts/restart_flask.service
+++ b/Scripts/restart_flask.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Restart Flask App
+
+[Service]
+Type=oneshot
+ExecStart=/home/nfrd/Server/restart_flask.sh

--- a/Scripts/restart_flask.sh
+++ b/Scripts/restart_flask.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Stop the Flask app
+pkill -f "python3 -m server"
+
+cd /home/nfrd/Server
+
+# Activate the Python environment
+source env/bin/activate
+
+# Restart the Flask app
+python3 -m server &
+
+echo "Flask app restarted at $(date)"

--- a/Scripts/restart_flask.timer
+++ b/Scripts/restart_flask.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run restart_flask.service every hour
+
+[Timer]
+OnCalendar=*:0
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## PR Documentation: Auto-Restart Flask App with Systemd Timer

### Overview:
This set of scripts and systemd configurations automate the process of restarting a Flask web application periodically every hour using systemd timers. By defining a service and timer, the Flask app will be automatically restarted every hour without manual intervention.

### Files Included:
1. **restart_flask.sh**: 
   - Description: Bash script responsible for stopping and restarting the Flask app.
   - Usage: Executed by systemd service unit.
   - Location: `/home/nfrd/Server/restart_flask.sh`

2. **restart_flask.service**:
   - Description: systemd service unit file defining how to execute the restart_flask.sh script.
   - Usage: Executed by systemd timer unit.
   - Location: `/etc/systemd/system/restart_flask.service`

3. **restart_flask.timer**:
   - Description: systemd timer unit file specifying when to trigger the restart_flask.service.
   - Usage: Automatically triggered by systemd based on specified schedule.
   - Location: `/etc/systemd/system/restart_flask.timer`

### How to Run:
1. **Ensure Python Virtual Environment**:
   - Make sure your Flask application is set up within a Python virtual environment.

2. **Configure Bash Script**:
   - Modify the `restart_flask.sh` script to include the correct paths and commands for stopping and restarting your Flask app. Ensure that the script is executable (`chmod +x restart_flask.sh`).

3. **Copy Service and Timer Files**:
   - Copy the `restart_flask.service` and `restart_flask.timer` files to the `/etc/systemd/system/` directory.

4. **Reload systemd Manager Configuration**:
   - Run `sudo systemctl daemon-reload` to reload systemd manager configuration.

5. **Start and Enable Timer**:
   - Start the timer unit: `sudo systemctl start restart_flask.timer`
   - Enable the timer to start on boot: `sudo systemctl enable restart_flask.timer`

### Verifying Operation:
- Check the status of the timer unit to ensure it's active and running: `sudo systemctl status restart_flask.timer`
- Monitor the systemd journal for logs related to the service unit: `journalctl -u restart_flask.service`

### Notes:
- Ensure that appropriate permissions are set for all scripts and systemd unit files.
- Adjust the timer schedule (`OnCalendar`) in the `restart_flask.timer` file according to your desired frequency.

![image](https://github.com/News-Feed-Rumor-Detector/NFRD/assets/60438793/ae69ace5-7f47-42d6-b60b-707035d8db22)
